### PR TITLE
Fix a bug in gulp cleaning

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -21,12 +21,13 @@ del = del.promise;
 
 const dev = {
   name: 'development',
+  buildOutput: ['dist/*', 'build/*'],
 
   /**
    * Delete all the built output.
    */
   async clean() {
-    await del(['dist/*', 'build/*', this.fingerprintsJsonFile]);
+    await del(this.buildOutput);
   },
 
   /**
@@ -81,6 +82,10 @@ const prod = {
 
   name: 'production',
   fingerprintsJsonFile: 'fingerprints.json',
+
+  get buildOutput() {
+    return ['dist/*', 'build/*', this.fingerprintsJsonFile];
+  },
 
   /**
    * Build any static HTML files, and put the output in the right place.
@@ -207,7 +212,8 @@ function watchedBuild(env) {
   };
 }
 
-exports.clean = dev.clean.bind(dev);
+exports.cleanDevelopment = dev.clean.bind(dev);
+exports.cleanProduction = prod.clean.bind(prod);
 exports.buildDevelopment = build(dev);
 exports.buildProduction = build(prod);
 exports.watchDevelopment = watchedBuild(dev);

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -54,7 +54,7 @@ const dev = {
       .pipe(elm())
       .pipe(rename('elm.js'))
       .pipe(gulp.dest('dist/'));
-},
+  },
 
   async addFingerprintsToFileNames() {
     log.info(

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "watch": "npx gulp watchDevelopment",
     "build": "npx gulp buildDevelopment",
     "build:prod": "npx gulp buildProduction",
-    "clean": "npx gulp clean",
+    "clean": "npx gulp cleanDevelopment",
+    "clean:prod": "npx gulp cleanProduction",
     "lint": "npx elm-analyse",
     "test": "npx elm-test"
   },


### PR DESCRIPTION
Now that "fingerprints" are only a thing that exist in production
builds, the development "clean" and production "clean" tasks have
different sets of files they need to delete.

(Previously, these tasks were trying to refer to each others' sets of
files, and there were a bunch of undefined variables--it was no good!)