### PR TITLE
Stop nginx from logging accesses in production

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -409,6 +409,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "binwrap": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.2.tgz",
@@ -1683,6 +1693,13 @@
       "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2217,6 +2234,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -7,12 +7,14 @@
 events {
 }
 
-error_log  /var/log/nginx/error.log;
+error_log /var/log/nginx/error.log;
 
 http {
   include mime.types;
 
-  access_log  /var/log/nginx/access.log;
+  # We expect to be running on a very small server where disk space is at a
+  # premium, so it isn't worth it to log accesses in production.
+  access_log off;
 
   server {
     listen 80;


### PR DESCRIPTION
We expect to be running this project on a small raspberry pi without
much disk space; and, while the access log doesn't take up very much
space, the utility it provides isn't worth the disk space it does
take up.